### PR TITLE
bugfix com.hilotec.opendocument

### DIFF
--- a/com.hilotec.elexis.opendocument/src/com/hilotec/elexis/opendocument/TextPlugin.java
+++ b/com.hilotec.elexis.opendocument/src/com/hilotec/elexis/opendocument/TextPlugin.java
@@ -255,9 +255,12 @@ public class TextPlugin implements ITextPlugin {
 					}
 					
 					if ((flags & SWT.BOLD) != 0) {
-						stp.setFoFontWeightAttribute("bold");
-					}
-					if ((flags & SWT.ITALIC) != 0) {
+                        stp.setFoFontWeightAttribute("bold");
+                    } else {
+                        stp.setFoFontWeightAttribute("normal");
+                    }
+
+                    if ((flags & SWT.ITALIC) != 0) {
 						stp.setFoFontStyleAttribute("italic");
 					}
 					


### PR DESCRIPTION
bugfix: com.hilotec.opendocument plugin TextPlugin class does not have the clause to add Normal text once the font has been set to BOLD